### PR TITLE
Remove homepage key from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,4 @@
 {
-  "homepage": "https://adornchoga.github.io/Math_Magicians/",
   "name": "my-app",
   "version": "0.1.0",
   "private": true,


### PR DESCRIPTION
In this pull request, removed the homepage key from package.json to configure netlify.